### PR TITLE
Simplify frontend forms

### DIFF
--- a/frontend/src/components/Tweet/ComposeTweet.jsx
+++ b/frontend/src/components/Tweet/ComposeTweet.jsx
@@ -7,7 +7,7 @@ import { useRouter } from "next/router";
 import session from "@/utils/session";
 
 export default function ComposeTweet({ handle }) {
-  const TEXT_CHAR_LIMIT = 240;
+  const TEXT_CHAR_LIMIT = 280;
   const [textArea, setTextArea] = useState("");
   const [user, setUser] = useState({});
   const tweetRef = useRef();
@@ -74,7 +74,7 @@ export default function ComposeTweet({ handle }) {
         <div className="w-14">
           <ProfilePicture handle={handle} />
         </div>
-        <div className="w-full">
+        <form onSubmit={onTweetSubmit} className="w-full">
           <ReactTextareaAutosize
             minRows={1}
             maxRows={10}
@@ -88,17 +88,17 @@ export default function ComposeTweet({ handle }) {
               <span className={getCharLimitIndicatorColor()}>
                 {textArea.length}
               </span>{" "}
-              / 240
+              / {TEXT_CHAR_LIMIT}
             </div>
             <button
-              type="button"
-              onClick={onTweetSubmit}
-              className="px-8 border rounded-full py-2 bg-blue-600 text-white flex justify-center items-center gap-2"
+              type="submit"
+              disabled={!textArea}
+              className="px-8 border rounded-full py-2 bg-blue-600 text-white flex justify-center items-center gap-2 disabled:opacity-60"
             >
               Woof
             </button>
           </div>
-        </div>
+        </form>
       </div>
     </>
   );

--- a/frontend/src/constants/ui/strings.js
+++ b/frontend/src/constants/ui/strings.js
@@ -6,7 +6,7 @@ export default {
     },
     LOGIN_FLOW: {
       signInCta: "Log in to Woofer",
-      email: "Email or username",
+      email: "Your email",
       password: "Enter your password",
       birthday: "Enter your date of birth",
       forgotPassword: "Forgot password?",

--- a/frontend/src/pages/auth/login.jsx
+++ b/frontend/src/pages/auth/login.jsx
@@ -60,7 +60,7 @@ export default function LoginFlow() {
       <h1 className="text-center text-3xl font-semibold">{uiText.signInCta}</h1>
       <div className="mt-8 flex justify-center">
         <div>
-          <form>
+          <form onSubmit={onSubmitForm}>
             <div>
               <label htmlFor="email">{uiText.email}</label>
               <input
@@ -87,8 +87,8 @@ export default function LoginFlow() {
             <div className="mt-6">
               <button
                 type="submit"
-                onClick={onSubmitForm}
-                className="px-4 w-full border rounded-full py-2 bg-blue-600 text-white"
+                disabled={!email || !password}
+                className="px-4 w-full border rounded-full py-2 bg-blue-600 text-white disabled:opacity-60"
               >
                 {uiText.signIn}
               </button>

--- a/frontend/src/pages/auth/login.jsx
+++ b/frontend/src/pages/auth/login.jsx
@@ -12,41 +12,8 @@ export default function LoginFlow() {
   const [uiText, setUiText] = useState(strings.EN.LOGIN_FLOW);
   const router = useRouter();
 
-  const onInputChange = (e) => {
-    const name = e.target.name;
-    const _loginForm = { ...loginForm };
-    _loginForm[name].value = e.target.value;
-    setLoginForm(_loginForm);
-  };
-
-  const onShowPasswordToggle = (status) => {
-    const _loginForm = { ...loginForm };
-    _loginForm.password.type = status ? "text" : "password";
-    setLoginForm(_loginForm);
-  };
-
-  const [loginForm, setLoginForm] = useState({
-    email: {
-      label: uiText.email,
-      htmlFor: "email",
-      type: "email",
-      required: true,
-      errorText: "",
-      value: "",
-      onChange: onInputChange,
-      validate: () => {},
-    },
-    password: {
-      label: <PasswordLabel onShowPasswordToggle={onShowPasswordToggle} />,
-      htmlFor: "password",
-      type: "password",
-      required: true,
-      errorText: "",
-      value: "",
-      onChange: onInputChange,
-      validate: () => {},
-    },
-  });
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
 
   useEffect(() => {
     // Detect and set the correct language here
@@ -62,8 +29,8 @@ export default function LoginFlow() {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        email: loginForm.email.value,
-        password: loginForm.password.value,
+        email,
+        password,
       }),
     })
       .then((response) => {
@@ -94,8 +61,28 @@ export default function LoginFlow() {
       <div className="mt-8 flex justify-center">
         <div>
           <form>
-            <Input {...loginForm.email} />
-            <Input {...loginForm.password} />
+            <div>
+              <label htmlFor="email">{uiText.email}</label>
+              <input
+                type="email"
+                id="email"
+                name="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                required
+              />
+            </div>
+            <div>
+              <label htmlFor="password">{uiText.password}</label>
+              <input
+                type="password"
+                id="password"
+                name="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                required
+              />
+            </div>
 
             <div className="mt-6">
               <button

--- a/frontend/src/pages/auth/register.jsx
+++ b/frontend/src/pages/auth/register.jsx
@@ -119,7 +119,8 @@ export default function RegisterFlow() {
             <div className="mt-6">
               <button
                 type="submit"
-                className="px-4 w-full border rounded-full py-2 bg-blue-600 text-white"
+                disabled={!email || !name || !password || !handle}
+                className="px-4 w-full border rounded-full py-2 bg-blue-600 text-white disabled:opacity-60"
               >
                 {uiText.register}
               </button>

--- a/frontend/src/pages/auth/register.jsx
+++ b/frontend/src/pages/auth/register.jsx
@@ -11,61 +11,15 @@ export default function RegisterFlow() {
   const [uiText, setUiText] = useState(strings.EN.REGISTER_FLOW);
   const router = useRouter();
 
-  const onInputChange = (e) => {
-    const name = e.target.name;
-    const _registrationForm = { ...registrationForm };
-    _registrationForm[name].value = e.target.value;
-    setRegistrationForm(_registrationForm);
-  };
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [handle, setHandle] = useState("");
 
-  const onShowPasswordToggle = (status) => {
-    const _registrationForm = { ...registrationForm };
-    _registrationForm.password.type = status ? "text" : "password";
-    setRegistrationForm(_registrationForm);
-  };
-
-  const [registrationForm, setRegistrationForm] = useState({
-    name: {
-      label: uiText.name,
-      htmlFor: "name",
-      type: "text",
-      required: true,
-      errorText: "",
-      value: "",
-      onChange: onInputChange,
-      validate: () => {},
-    },
-    email: {
-      label: uiText.email,
-      htmlFor: "email",
-      type: "email",
-      required: true,
-      errorText: "",
-      value: "",
-      onChange: onInputChange,
-      validate: () => {},
-    },
-    password: {
-      label: <PasswordLabel onShowPasswordToggle={onShowPasswordToggle} />,
-      htmlFor: "password",
-      type: "password",
-      required: true,
-      errorText: "",
-      value: "",
-      onChange: onInputChange,
-      validate: () => {},
-    },
-    handle: {
-      label: uiText.handle,
-      htmlFor: "handle",
-      type: "text",
-      required: true,
-      errorText: "",
-      value: "",
-      onChange: onInputChange,
-      validate: () => {},
-    },
-  });
+  // @TODO: Show validation errors for these fields
+  const [emailError, setEmailError] = useState("");
+  const [passwordError, setPasswordError] = useState("");
+  const [handleError, setHandleError] = useState("");
 
   useEffect(() => {
     // Detect and set the correct language here
@@ -80,10 +34,10 @@ export default function RegisterFlow() {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        name: registrationForm.name.value,
-        handle: registrationForm.handle.value,
-        email: registrationForm.email.value,
-        password: registrationForm.password.value,
+        name,
+        handle,
+        email,
+        password,
       }),
     })
       .then((response) => {
@@ -116,16 +70,55 @@ export default function RegisterFlow() {
       </h1>
       <div className="mt-8 flex justify-center">
         <div className="w-64">
-          <form>
-            <Input {...registrationForm.name} />
-            <Input {...registrationForm.email} />
-            <Input {...registrationForm.password} />
-            <Input {...registrationForm.handle} />
+          <form onSubmit={onSubmitForm}>
+            <div>
+              <label htmlFor="name">{uiText.name}</label>
+              <input
+                type="text"
+                id="name"
+                name="name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                required
+              />
+            </div>
+            <div>
+              <label htmlFor="email">{uiText.email}</label>
+              <input
+                type="email"
+                id="email"
+                name="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                required
+              />
+            </div>
+            <div>
+              <label htmlFor="password">{uiText.password}</label>
+              <input
+                type="password"
+                id="password"
+                name="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                required
+              />
+            </div>
+            <div>
+              <label htmlFor="handle">{uiText.handle}</label>
+              <input
+                type="text"
+                id="handle"
+                name="handle"
+                value={handle}
+                onChange={(event) => setHandle(event.target.value)}
+                required
+              />
+            </div>
 
             <div className="mt-6">
               <button
-                type="button"
-                onClick={onSubmitForm}
+                type="submit"
                 className="px-4 w-full border rounded-full py-2 bg-blue-600 text-white"
               >
                 {uiText.register}

--- a/frontend/src/pages/settings/accountDetails.jsx
+++ b/frontend/src/pages/settings/accountDetails.jsx
@@ -6,14 +6,8 @@ import { toast } from "react-hot-toast";
 
 export default function AccountDetailsPage() {
   const uiText = strings.EN.SETTINGS;
-  const [userFromServer, setUserFromServer] = useState({});
-
-  const onInputChange = (e) => {
-    const name = e.target.name;
-    const _accountDetailsForm = { ...accountDetailsForm };
-    _accountDetailsForm[name].value = e.target.value;
-    setAccountDetailsForm(_accountDetailsForm);
-  };
+  const [bio, setBio] = useState("");
+  const [website, setWebsite] = useState("");
 
   useEffect(() => {
     const getUserFromServer = async () => {
@@ -23,11 +17,8 @@ export default function AccountDetailsPage() {
         });
         const userResBody = await userRes.json();
         const user = userResBody.data.user;
-        setUserFromServer(user);
-
-        _accountDetailsForm = { ...accountDetailsForm };
-        _accountDetailsForm.bio.value = user.bio;
-        _accountDetailsForm.website.value = user.website;
+        setBio(user.bio);
+        setWebsite(user.website);
       } catch (error) {
         console.log(error);
       }
@@ -35,29 +26,6 @@ export default function AccountDetailsPage() {
 
     getUserFromServer();
   }, []);
-
-  const [accountDetailsForm, setAccountDetailsForm] = useState({
-    bio: {
-      label: uiText.yourBio,
-      htmlFor: "bio",
-      type: "textarea",
-      required: true,
-      errorText: "",
-      value: "",
-      onChange: onInputChange,
-      validate: () => {},
-    },
-    website: {
-      label: uiText.website,
-      htmlFor: "website",
-      type: "url",
-      required: false,
-      errorText: "",
-      value: "",
-      onChange: onInputChange,
-      validate: () => {},
-    },
-  });
 
   const onSubmitUpdateDetails = async (e) => {
     e.preventDefault();
@@ -69,8 +37,8 @@ export default function AccountDetailsPage() {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        bio: accountDetailsForm.website.value,
-        website: accountDetailsForm.bio.value,
+        bio,
+        website,
       }),
     })
       .then((response) => {
@@ -94,20 +62,40 @@ export default function AccountDetailsPage() {
   };
 
   return (
-    <div>
+    <div className="pt-2">
       <h2 className="font-bold text-2xl">{uiText.accountDetails}</h2>
       <div className="mt-4">
-        <form>
-          <Input {...accountDetailsForm.bio} />
-          <Input {...accountDetailsForm.website} />
+        <form onSubmit={onSubmitUpdateDetails}>
+          <div>
+            <label htmlFor="bio">{uiText.yourBio}</label>
+            <input
+              type="text"
+              id="bio"
+              name="bio"
+              value={bio}
+              onChange={(event) => setBio(event.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="website">{uiText.website}</label>
+            <input
+              type="url"
+              id="website"
+              name="website"
+              value={website}
+              onChange={(event) => setWebsite(event.target.value)}
+              required
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={!bio || !website}
+            className="px-4 w-full border rounded-full py-2 bg-blue-600 text-white mt-4 disabled:opacity-60"
+          >
+            {uiText.update}
+          </button>
         </form>
-
-        <button
-          onClick={onSubmitUpdateDetails}
-          className="px-4 w-full border rounded-full py-2 bg-blue-600 text-white mt-4"
-        >
-          {uiText.update}
-        </button>
       </div>
     </div>
   );

--- a/frontend/src/pages/settings/changePassword.jsx
+++ b/frontend/src/pages/settings/changePassword.jsx
@@ -7,67 +7,9 @@ import toast from "react-hot-toast";
 
 export default function ChangePassword() {
   const uiText = strings.EN.SETTINGS;
-
-  const onInputChange = (e) => {
-    const name = e.target.name;
-    const _changePasswordForm = { ...changePasswordForm };
-    _changePasswordForm[name].value = e.target.value;
-    setChangePasswordForm(_changePasswordForm);
-  };
-
-  const onShowPasswordToggle = (status, name) => {
-    const _changePasswordForm = { ...changePasswordForm };
-    _changePasswordForm[name].type = status ? "text" : "password";
-    setChangePasswordForm(_changePasswordForm);
-  };
-
-  const INITIAL_FORM_STATE = {
-    currentPassword: {
-      label: (
-        <PasswordLabel
-          onShowPasswordToggle={onShowPasswordToggle}
-          name="currentPassword"
-        />
-      ),
-      htmlFor: "currentPassword",
-      type: "password",
-      required: true,
-      errorText: "",
-      value: "",
-      onChange: onInputChange,
-      validate: () => {},
-    },
-    newPassword: {
-      label: (
-        <PasswordLabel
-          onShowPasswordToggle={onShowPasswordToggle}
-          name="newPassword"
-        />
-      ),
-      htmlFor: "newPassword",
-      type: "password",
-      required: true,
-      errorText: "",
-      value: "",
-      onChange: onInputChange,
-      validate: () => {},
-    },
-    newPasswordAgain: {
-      label: (
-        <PasswordLabel
-          onShowPasswordToggle={onShowPasswordToggle}
-          name="newPasswordAgain"
-        />
-      ),
-      htmlFor: "newPasswordAgain",
-      type: "password",
-      required: true,
-      errorText: "",
-      value: "",
-      onChange: onInputChange,
-      validate: () => {},
-    },
-  };
+  const [oldPassword, setOldPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
 
   const onSubmitChangePassword = (e) => {
     e.preventDefault();
@@ -79,9 +21,9 @@ export default function ChangePassword() {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        oldPassword: changePasswordForm.currentPassword.value,
-        newPassword: changePasswordForm.newPassword.value,
-        confirmPassword: changePasswordForm.newPasswordAgain.value,
+        oldPassword,
+        newPassword,
+        confirmPassword,
       }),
     })
       .then((response) => {
@@ -89,8 +31,9 @@ export default function ChangePassword() {
           // Redirect the user to their profile page
           response.json().then((body) => {
             toast.success("Password changed successfully");
-            // @TODO: Fix this, it doesn't work
-            setChangePasswordForm(INITIAL_FORM_STATE);
+            setOldPassword("");
+            setNewPassword("");
+            setConfirmPassword("");
           });
         } else {
           // Login failed
@@ -106,26 +49,50 @@ export default function ChangePassword() {
       });
   };
 
-  const [changePasswordForm, setChangePasswordForm] =
-    useState(INITIAL_FORM_STATE);
-
   return (
     <div>
       <h2 className="font-bold text-2xl">{uiText.changePassword}</h2>
-      <form>
-        <Input {...changePasswordForm.currentPassword} />
-        <Input {...changePasswordForm.newPassword} />
-        <Input {...changePasswordForm.newPasswordAgain} />
+      <form onSubmit={onSubmitChangePassword}>
+        <div>
+          <label htmlFor="oldPassword">{uiText.currentPassword}</label>
+          <input
+            type="password"
+            id="oldPassword"
+            name="oldPassword"
+            value={oldPassword}
+            onChange={(event) => setOldPassword(event.target.value)}
+            required
+          />
+        </div>
+
+        <div>
+          <label htmlFor="newPassword">{uiText.newPassword}</label>
+          <input
+            type="password"
+            id="newPassword"
+            name="newPassword"
+            value={newPassword}
+            onChange={(event) => setNewPassword(event.target.value)}
+            required
+          />
+        </div>
+
+        <div>
+          <label htmlFor="confirmPassword">{uiText.newPasswordAgain}</label>
+          <input
+            type="password"
+            id="confirmPassword"
+            name="confirmPassword"
+            value={confirmPassword}
+            onChange={(event) => setConfirmPassword(event.target.value)}
+            required
+          />
+        </div>
 
         <div className="mt-8">
           <button
             type="submit"
-            onClick={onSubmitChangePassword}
-            disabled={
-              !changePasswordForm.currentPassword.value ||
-              !changePasswordForm.newPassword.value ||
-              !changePasswordForm.newPasswordAgain.value
-            }
+            disabled={!oldPassword || !newPassword || !confirmPassword}
             className="px-4 w-full border rounded-full py-2 bg-blue-600 text-white mt-4 disabled:opacity-60"
           >
             {uiText.changePassword}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -11,3 +11,11 @@ html,
 body {
   @apply overscroll-y-none;
 }
+
+label {
+  @apply font-semibold block mt-3;
+}
+
+input {
+  @apply px-2 py-2 rounded border block mt-1 border-gray-400 w-full;
+}


### PR DESCRIPTION
I had originally added a lot of abstractions to forms and tried to make it all work from a JS object, but it feels like overkill in hindsight, especially for a workshop where students are supposed to learn the basics. 

This PR gets rid of the abstractions and keeps things simple (as they should be!)